### PR TITLE
fix(web): add @nuxt/vite-builder prod dep; ENV-driven ports; stable Nitro start

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,32 @@ Use the production Docker setup below to deploy quickly with Docker Hub images a
   - Ensure hidden-layer content (docs/, internal/, glyphs/) is not staged.
 - Open PRs using the provided template; include governance adherence and runtime ports.
 
+### Sprint End Ritual
+- Merge the feature branch to `main` when all CI checks are green.
+- Append the latest changes to the `Changelog` section in this `README.md`.
+- Create and push an annotated tag for the release:
+  ```bash
+  VERSION=v0.2.3
+  git tag -a "$VERSION" -m "release: $VERSION"
+  git push origin "$VERSION"
+  ```
+- Delete the merged branch locally and on origin:
+  ```bash
+  BR=feat/v0.2.3-seo-security-editor
+  git branch -d "$BR" || true
+  git push origin --delete "$BR" || true
+  ```
+- Deploy production images (Docker Hub pull + compose up):
+  ```bash
+  # Ensure .env.prod is present (see .env.prod.example)
+  docker compose --env-file .env.prod -f docker-compose.prod.yml pull
+  docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+  ```
+- Post-merge smoke test: confirm `.github/workflows/post-merge-smoke.yml` passes
+  against the remote API URL (checks auth, basic endpoints, and og:image).
+- Governance upkeep: keep branch protection required checks in sync with
+  current workflow job names to avoid stale/phantom failures.
+
 ### Optional local pre-commit hook
 Create a local git hook to block commits if checks fail:
 
@@ -171,3 +197,15 @@ Notes:
   - Seeds a CI `.env` with `JWT_SECRET` (from `E2E_JWT_SECRET` secret), `API_BASE`, and `NUXT_PUBLIC_API_BASE`.
   - Installs Playwright browsers and runs the E2E suite with the frontend on `FRONTEND_PORT=5999`.
   - Tears down Docker after completion.
+
+---
+
+## Changelog
+
+### v0.2.3 — 2025-08-31
+- CI/Vitest: remove unsupported CLI flags; scope via `apps/web/vitest.config.ts` `test.include`.
+- CI: run `web-build` inside `apps/web`; add diagnostics (commit SHA, scripts, Vitest version).
+- E2E: Dockerized API healthchecks and health wait loop for stable Playwright runs.
+- Workflows: `Glyph & Docs Guard` installs `apps/api` deps and adds diagnostics; root `test:all` installs API deps.
+- Post-merge smoke workflow added to validate prod-like API URL.
+- Docs: add Sprint End Ritual and changelog.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@nuxt/vite-builder": "^3.12.0",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@pinia/nuxt": "^0.5.1",
     "nuxt": "^3.12.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "nuxt dev -p 5000 -H 0.0.0.0",
+    "dev": "HOST=${HOST:-0.0.0.0} nuxt dev -p ${PORT:-5000} -H ${HOST}",
     "build": "nuxt build",
-    "start": "node .output/server/index.mjs",
+    "start": "HOST=${HOST:-0.0.0.0} PORT=${PORT:-5000} node .output/server/index.mjs",
     "typecheck": "npx nuxi typecheck",
     "lint": "eslint --ext .js,.ts,.vue .",
     "test": "vitest run",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nuxt dev -p 5000 -H 0.0.0.0",
     "build": "nuxt build",
-    "start": "nuxt start -p 5000 -H 0.0.0.0",
+    "start": "node .output/server/index.mjs",
     "typecheck": "npx nuxi typecheck",
     "lint": "eslint --ext .js,.ts,.vue .",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Add @nuxt/vite-builder to production dependencies so Nuxt 3.12 server can resolve runtime import (client.manifest.mjs) in prod/dev containers.
- Change start to run Nitro directly:  to avoid nitro.json resolution issues.
- Make dev/start respect HOST and PORT env (defaults HOST=0.0.0.0, PORT=5000). Supports docker-compose mapping 5588:5000.

## Glyphs Referenced
- Primary: N/A
- Related: MSH-000 (mesh/docs upkeep)

## Governance Adherence
- Conventional commits followed (GVN-002): yes
- Branch rule respected (GVN-004): yes, branch name: fix/nuxt-vite-builder-runtime
- Created from latest main: yes
- Up-to-date with main before PR: yes
- Hidden layer protected (GOV-SEC-001): yes
- Mesh index updated if needed (MSH-000): N/A

## Runtime Ports
- API: 3388
- Web: 5588 (host) -> 5000 (container)
- DB: 5433 (host) -> 5432 (container)

## Validation & Checks
- [x] 
> glyphic-blog@0.1.0 test:docs
> node scripts/validate-glyphs.js

✔ All MESH IDs have corresponding files
✔ Glyph filenames valid and IDs unique passes
- [x] 
> glyphic-blog@0.1.0 guard:internal
> node scripts/guard-internal-docs.js

✔ No forbidden internal doc paths in diff passes
- [x] CI glyph/docs checks pass
- [x] Branch policy check passes (rebased/merged main locally)

## Screenshots / Logs
- Local dev via docker-compose now serves without 500 (client.manifest) and without nitro.json path error.
