### PR TITLE
feat(api,web): RFC 6750 auth errors + UI surfacing; footer version label

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ PUBLIC_BASE_URL=http://localhost:3000
 NUXT_PUBLIC_API_BASE=http://localhost:3000
 # Optional: Fallback social image used when a post has no image
 NUXT_PUBLIC_SOCIAL_FALLBACK=
+# Optional: App version label shown in footer (e.g., v0.2.3). If unset, falls back to package version or 'dev'.
+NUXT_PUBLIC_APP_VERSION=
 
 # ==== E2E (Playwright) ====
 # Base URL where the Docker-exposed API is reachable from the host

--- a/README.md
+++ b/README.md
@@ -253,3 +253,5 @@ Notes:
 - Workflows: `Glyph & Docs Guard` installs `apps/api` deps and adds diagnostics; root `test:all` installs API deps.
 - Post-merge smoke workflow added to validate prod-like API URL.
 - Docs: add Sprint End Ritual and changelog.
+ - API: RFC 6750-compliant auth errors (WWW-Authenticate) with specific codes (`token_missing`, `token_invalid`, `token_expired`, `insufficient_scope`, `auth_required`).
+ - Web: surface API auth errors via toast with friendly messages; add footer version label (`Blog vX.Y.Z`).

--- a/apps/api/data/posts.json
+++ b/apps/api/data/posts.json
@@ -1,5 +1,59 @@
 [
   {
+    "id": "78739724-4d90-40fc-bb6c-00a047e2c0d9",
+    "title": "ok",
+    "content": "",
+    "slug": "ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T08:54:59.104Z",
+    "updatedAt": "2025-09-09T08:54:59.104Z"
+  },
+  {
+    "id": "c7f41464-7fb1-4b23-bc3f-a8e5717ad089",
+    "title": "fallback ok",
+    "content": "",
+    "slug": "fallback-ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T08:54:59.100Z",
+    "updatedAt": "2025-09-09T08:54:59.100Z"
+  },
+  {
+    "id": "df4496b8-348c-4110-918a-bcaeaf7b985c",
+    "title": "JWT ok",
+    "content": "",
+    "slug": "jwt-ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T08:54:59.092Z",
+    "updatedAt": "2025-09-09T08:54:59.092Z"
+  },
+  {
+    "id": "1783efd9-e018-4e53-8988-585e9a352f1d",
+    "title": "ok",
+    "content": "",
+    "slug": "ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T08:47:44.934Z",
+    "updatedAt": "2025-09-09T08:47:44.934Z"
+  },
+  {
+    "id": "a284e5fd-94f0-45f0-9a25-96cba6803159",
+    "title": "fallback ok",
+    "content": "",
+    "slug": "fallback-ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T08:47:44.926Z",
+    "updatedAt": "2025-09-09T08:47:44.926Z"
+  },
+  {
+    "id": "de94fff8-4c7b-4622-9e6a-c9402ee78e20",
+    "title": "JWT ok",
+    "content": "",
+    "slug": "jwt-ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T08:47:44.919Z",
+    "updatedAt": "2025-09-09T08:47:44.919Z"
+  },
+  {
     "id": "bfc64f4d-7d9b-4fbf-a02a-ee71658bf54f",
     "title": "E2E Post 1756626588400",
     "content": "Hello from E2E at 2025-08-31T07:49:48.400Z",

--- a/apps/api/test/api.test.js
+++ b/apps/api/test/api.test.js
@@ -48,8 +48,8 @@ test('JWT without admin claim is rejected (401)', async () => {
   process.env.JWT_SECRET = 'test-secret'
   const token = jwt.sign({ role: 'user' }, process.env.JWT_SECRET)
   const { status, data } = await json('POST', '/api/posts', { title: 'JWT bad', content: '' }, token)
-  assert.equal(status, 401)
-  assert.equal(data.error, 'unauthorized')
+  assert.equal(status, 403)
+  assert.equal(data.error, 'insufficient_scope')
 })
 
 test('When JWT verify fails but static token matches, allow via fallback', async () => {
@@ -136,22 +136,22 @@ test('GET /api/posts returns array', async () => {
 
 // Unauthorized write
 
-test('POST /api/posts without token -> 401', async () => {
+test('POST /api/posts without token -> 401 token_missing', async () => {
   const { status, data } = await json('POST', '/api/posts', { title: 't', content: 'c' })
   assert.equal(status, 401)
-  assert.equal(data.error, 'unauthorized')
+  assert.equal(data.error, 'token_missing')
 })
 
 // Upload auth
 
-test('POST /api/upload without token -> 401', async () => {
+test('POST /api/upload without token -> 401 token_missing', async () => {
   const form = new FormData()
   const blob = new Blob([Buffer.from('89504e470d0a1a0a', 'hex')], { type: 'image/png' })
   form.set('image', blob, 'tiny.png')
   const res = await fetch(baseURL + '/api/upload', { method: 'POST', body: form })
   assert.equal(res.status, 401)
   const body = await res.json()
-  assert.equal(body.error, 'unauthorized')
+  assert.equal(body.error, 'token_missing')
 })
 
 test('POST /api/upload with token -> 200 and url', async () => {

--- a/apps/web/app.vue
+++ b/apps/web/app.vue
@@ -99,6 +99,7 @@
         >
           Blog
         </a>
+        <span v-if="appVersion">&nbsp;v{{ appVersion }}</span>
       </div>
     </footer>
   </div>
@@ -108,6 +109,7 @@
 import { useAuth } from '~/stores/auth'
 import { useRoute, useRouter } from 'vue-router'
 import { onMounted, ref } from 'vue'
+import { useRuntimeConfig } from 'nuxt/app'
 
 const auth = useAuth()
 const route = useRoute()
@@ -119,6 +121,10 @@ const loginError = ref('')
 // Editable site title
 const siteTitle = ref('Glyphic Blog')
 const editingTitle = ref(false)
+
+// App version from runtime config
+const runtime = useRuntimeConfig()
+const appVersion = (runtime.public as any)?.appVersion || ''
 
 // Synchronous init to avoid flicker before first paint
 if (typeof window !== 'undefined') {

--- a/apps/web/composables/useErrors.ts
+++ b/apps/web/composables/useErrors.ts
@@ -1,0 +1,27 @@
+export type ApiErrorLike = Error & { status?: number; code?: string; description?: string }
+
+const messages: Record<string, string> = {
+  token_missing: 'Authentication required. Please provide your token.',
+  token_invalid: 'Your token is invalid. Please check and try again.',
+  token_expired: 'Your token has expired. Generate a new one and try again.',
+  insufficient_scope: 'Your token lacks permission to edit. Admin scope required.',
+  auth_required: 'Authentication is required to perform this action.',
+}
+
+export function useErrors() {
+  function messageForCode(code?: string, fallback?: string) {
+    if (!code) return fallback || 'Request failed'
+    return messages[code] || fallback || 'Request failed'
+  }
+
+  function formatApiError(e: unknown): { title: string; detail?: string; code?: string } {
+    const err = (e || {}) as ApiErrorLike
+    const code = err.code || ''
+    const desc = err.description || ''
+    const title = messageForCode(code, err.message)
+    const detail = desc || undefined
+    return { title, detail, code }
+  }
+
+  return { formatApiError }
+}

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -20,6 +20,8 @@ export default defineNuxtConfig({
       apiBase: process.env.NUXT_PUBLIC_API_BASE || 'http://localhost:3388',
       // Used by pages/p/[slug].vue for OG/Twitter image fallback
       socialFallback: process.env.NUXT_PUBLIC_SOCIAL_FALLBACK || '',
+      // Version label shown in footer. Prefer explicit env, otherwise fall back to package version or 'dev'.
+      appVersion: process.env.NUXT_PUBLIC_APP_VERSION || process.env.APP_VERSION || process.env.npm_package_version || 'dev',
     },
   },
   typescript: {

--- a/apps/web/pages/index.vue
+++ b/apps/web/pages/index.vue
@@ -210,6 +210,7 @@ import { useSlug } from '~/composables/useSlug'
 import { usePasteMedia } from '~/composables/usePasteMedia'
 import { useComposerKeys } from '~/composables/useComposerKeys'
 import { useApi } from '~/composables/useApi'
+import { useErrors } from '~/composables/useErrors'
 
 const router = useRouter()
 const route = useRoute()
@@ -220,6 +221,8 @@ const api = useApi()
 // Shared composables
 const { renderContent, firstImageUrl: _firstImageUrl } = useContent()
 const { titleToSlug, canonicalSlug, postUrl: _postUrl, xShareUrl } = useSlug()
+// Error formatting helper
+const { formatApiError } = useErrors()
 
 // SEO: homepage head tags and optional preload of fallback social image
 const runtime = useRuntimeConfig()
@@ -294,7 +297,9 @@ async function fetchPosts() {
   try {
     posts.value = await api.get('/posts')
   } catch (e: any) {
-    error.value = e?.message || 'Failed to load posts'
+    const info = formatApiError(e)
+    error.value = info.title
+    showToast(info.title, 'error')
   } finally {
     loading.value = false
   }
@@ -327,7 +332,9 @@ async function create() {
     await nextTick()
     setupReveal()
   } catch (e: any) {
-    error.value = e?.message || 'Failed to create post'
+    const info = formatApiError(e)
+    error.value = info.title
+    showToast(info.title, 'error')
   }
 }
 
@@ -337,8 +344,9 @@ async function remove(id: string) {
     posts.value = posts.value.filter(p => p.id !== id)
     showToast('Deleted', 'success')
   } catch (e: any) {
-    error.value = e?.message || 'Failed to delete post'
-    showToast('Delete failed', 'error')
+    const info = formatApiError(e)
+    error.value = info.title
+    showToast(info.title, 'error')
   }
 }
 
@@ -376,8 +384,9 @@ async function saveEdit() {
     if (i !== -1) posts.value[i] = updated
     showToast('Saved', 'success')
   } catch (e: any) {
-    error.value = e?.message || 'Failed to save post'
-    showToast('Save failed', 'error')
+    const info = formatApiError(e)
+    error.value = info.title
+    showToast(info.title, 'error')
   } finally {
     editingId.value = null
   }


### PR DESCRIPTION
Summary
- API now returns clear, standards-compliant JWT auth errors with WWW-Authenticate headers and structured error codes: token_missing, token_invalid, token_expired, insufficient_scope, auth_required.
- Frontend parses these errors and surfaces friendly toast messages.
- Footer shows “Blog v{version}” from runtime config (NUXT_PUBLIC_APP_VERSION | APP_VERSION | npm_package_version | dev).

Changes
- API: apps/api/src/app.js — enhanced requireAuth():
  - Missing token -> 401 token_missing
  - Invalid/expired token -> 401 token_invalid / token_expired
  - Insufficient permissions -> 403 insufficient_scope
  - No auth configured (and insecure writes disabled) -> 401 auth_required
  - RFC 6750 WWW-Authenticate headers on failures.
- Web:
  - apps/web/composables/useApi.ts — parse JSON error + WWW-Authenticate; throw Error with .status/.code/.description.
  - apps/web/composables/useErrors.ts — code-to-message mapping + formatter.
  - apps/web/pages/index.vue — use toasts to surface API errors in load/create/update/delete flows.
  - apps/web/nuxt.config.ts — expose public.appVersion.
  - apps/web/app.vue — render “Blog v{version}” in footer.
  - .env.example — document NUXT_PUBLIC_APP_VERSION.
- Docs: README changelog updated under v0.2.3.
- Tests: API tests updated to new error semantics; all tests pass.

Testing
- npm run test:all → API tests + docs guards pass.
- (apps/web) npm run test:unit → all unit tests pass.
- E2E continues using HS256 JWT signed with JWT_SECRET against Docker API (API_BASE).

Governance / Ritual
- Feature branch: feat/jwt-auth-errors.
- After merge:
  - Delete branch local/remote:
    - git branch -d feat/jwt-auth-errors || true
    - git push origin --delete feat/jwt-auth-errors || true
  - Ensure changelog is updated (done in README.md for v0.2.3).
  - Tag release v0.2.3 when everything for the sprint is ready:
    - VERSION=v0.2.3
    - git tag -a "$VERSION" -m "release: $VERSION"
    - git push origin "$VERSION"