### PR TITLE
docs(governance): GOV-CORE-013 post-merge ritual + workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,5 +24,9 @@
 - [ ] CI glyph/docs checks pass
 - [ ] Branch policy check passes (rebased/merged main locally)
 
+## Post-Merge Ritual (GOV-CORE-013)
+- [ ] Acknowledge that the merged branch will be deleted (auto-cleanup workflow runs on merge)
+- [ ] Confirm `README.md` Changelog includes this PR under the current sprint tag (Action posts a reminder comment)
+
 ## Screenshots / Logs
 <!-- Optional: attach evidence for reviewers -->

--- a/.github/workflows/post-merge-ritual.yml
+++ b/.github/workflows/post-merge-ritual.yml
@@ -1,0 +1,53 @@
+name: Post-Merge Ritual
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cleanup-and-remind:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Delete merged branch (if not main)
+        if: github.event.pull_request.head.ref != github.event.pull_request.base.ref
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [ "$BRANCH" != "main" ]; then
+            echo "Deleting merged branch: $BRANCH"
+            # Delete remote branch; ignore error if already deleted or protected
+            curl -s -X DELETE \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/$REPO/git/refs/heads/$BRANCH" \
+              || true
+          fi
+
+      - name: Post changelog reminder comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const body = [
+              'Post-merge ritual executed:',
+              '- [x] Branch auto-delete attempted.',
+              '- [ ] Verify README.md changelog includes this PR under current sprint tag.',
+              '',
+              'If not, please add a line under the Changelog section now.\n\n— GOV-CORE-013'
+            ].join('\n')
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            })

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -17,3 +17,8 @@ From tag → tag, freeze glyph names/codenames. Use deprecation notes; don’t r
 
 CODENAME: GOV-CORE-012 — ADRs (tiny)
 If a decision changes intent (not just code), add a 10–15 line ADR under internal/adr/ and reference it in the PR.
+
+CODENAME: GOV-CORE-013 — Post-Merge Ritual
+- After a PR is merged into main, delete the feature branch locally and on origin.
+- Ensure the `README.md` Changelog section contains a line for the change set (or aggregate under the current sprint tag).
+- Tag the release at sprint end (see README Sprint End Ritual). A GitHub Action will assist by auto-deleting merged branches and posting a reminder comment.


### PR DESCRIPTION
Formalize post-merge ritual: auto-delete merged branches and post changelog reminder via workflow; update governance doc and PR template.