### PR TITLE
feat(web,api): authz feedback via /api/authz + title hydration fix

### DIFF
--- a/apps/api/data/posts.json
+++ b/apps/api/data/posts.json
@@ -1,5 +1,59 @@
 [
   {
+    "id": "47f959c8-8b6d-4bf5-a8cb-35b3fae440a8",
+    "title": "ok",
+    "content": "",
+    "slug": "ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T11:14:02.949Z",
+    "updatedAt": "2025-09-09T11:14:02.949Z"
+  },
+  {
+    "id": "a0be6fc2-3437-4c4b-bbf1-a11f143f079b",
+    "title": "fallback ok",
+    "content": "",
+    "slug": "fallback-ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T11:14:02.935Z",
+    "updatedAt": "2025-09-09T11:14:02.935Z"
+  },
+  {
+    "id": "ca068a3c-8233-4f69-a40f-d73f258d3708",
+    "title": "JWT ok",
+    "content": "",
+    "slug": "jwt-ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T11:14:02.922Z",
+    "updatedAt": "2025-09-09T11:14:02.922Z"
+  },
+  {
+    "id": "abd3b633-d2ea-4efa-befc-1ff4ca92487a",
+    "title": "ok",
+    "content": "",
+    "slug": "ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T11:13:11.943Z",
+    "updatedAt": "2025-09-09T11:13:11.943Z"
+  },
+  {
+    "id": "e615408c-dabb-44bf-8415-b9599d036e3c",
+    "title": "fallback ok",
+    "content": "",
+    "slug": "fallback-ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T11:13:11.931Z",
+    "updatedAt": "2025-09-09T11:13:11.931Z"
+  },
+  {
+    "id": "f13f3228-7708-4e96-9f14-85009c4ab68b",
+    "title": "JWT ok",
+    "content": "",
+    "slug": "jwt-ok",
+    "status": "draft",
+    "createdAt": "2025-09-09T11:13:11.907Z",
+    "updatedAt": "2025-09-09T11:13:11.907Z"
+  },
+  {
     "id": "78739724-4d90-40fc-bb6c-00a047e2c0d9",
     "title": "ok",
     "content": "",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -179,6 +179,11 @@ app.delete('/api/posts/:id', requireAuth, (req, res) => {
   res.json({ ok: true, id: removed.id })
 })
 
+// Authorization probe
+app.get('/api/authz', requireAuth, (_req, res) => {
+  res.json({ ok: true })
+})
+
 // File uploads
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, uploadsDir),

--- a/apps/api/test/api.test.js
+++ b/apps/api/test/api.test.js
@@ -125,6 +125,35 @@ test('health returns ok', async () => {
   assert.equal(body.ok, true)
 })
 
+// Authz probe
+
+test('GET /api/authz with admin claim -> 200', async () => {
+  const jwt = require('jsonwebtoken')
+  process.env.JWT_SECRET = 'test-secret'
+  const token = jwt.sign({ role: 'admin' }, process.env.JWT_SECRET)
+  const res = await fetch(baseURL + '/api/authz', { headers: { Authorization: `Bearer ${token}` } })
+  assert.equal(res.status, 200)
+  const body = await res.json()
+  assert.equal(body.ok, true)
+})
+
+test('GET /api/authz without admin claim -> 403 insufficient_scope', async () => {
+  const jwt = require('jsonwebtoken')
+  process.env.JWT_SECRET = 'test-secret'
+  const token = jwt.sign({ role: 'user' }, process.env.JWT_SECRET)
+  const res = await fetch(baseURL + '/api/authz', { headers: { Authorization: `Bearer ${token}` } })
+  assert.equal(res.status, 403)
+  const body = await res.json()
+  assert.equal(body.error, 'insufficient_scope')
+})
+
+test('GET /api/authz without token -> 401 token_missing', async () => {
+  const res = await fetch(baseURL + '/api/authz')
+  assert.equal(res.status, 401)
+  const body = await res.json()
+  assert.equal(body.error, 'token_missing')
+})
+
 // Read list
 
 test('GET /api/posts returns array', async () => {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.0.1",
       "dependencies": {
+        "@nuxt/vite-builder": "^3.12.0",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "@pinia/nuxt": "^0.5.1",
         "nuxt": "^3.12.0",


### PR DESCRIPTION
Summary
- Add GET /api/authz protected endpoint to confirm authorization.
- Web: verify JWT against /api/authz before enabling edit mode; show clear error if insufficient scope.
- Web: wrap site title in ClientOnly to avoid SSR/CSR mismatch.

Files
- apps/api/src/app.js: add /api/authz
- apps/web/app.vue: authz check on submitToken; ClientOnly header title
- apps/api/test/api.test.js: tests for /api/authz success/insufficient/missing token

Governance
- Conventional commit; feature branch; tests updated; docs unchanged.