### PR TITLE
chore(compose): pass NUXT_PUBLIC_APP_VERSION to web; drop obsolete version key

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   db:
     image: postgres:16
@@ -33,6 +32,7 @@ services:
       PORT: 5000
       HOST: 0.0.0.0
       NUXT_PUBLIC_API_BASE: ${NUXT_PUBLIC_API_BASE}
+      NUXT_PUBLIC_APP_VERSION: ${NUXT_PUBLIC_APP_VERSION}
     depends_on:
       - api
     ports:


### PR DESCRIPTION
This enables the footer version display in prod by passing NUXT_PUBLIC_APP_VERSION to the web container, and removes the obsolete top-level compose version key (Compose v2 warns and ignores it).