### PR TITLE
chore(gov): centralize governance (docs/glyphs) to code/governance/blog with validator fallback

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,2 @@
+This repository's governance docs have been centralized.
+Primary location: ../governance/blog/docs/

--- a/glyphs/README.md
+++ b/glyphs/README.md
@@ -1,0 +1,2 @@
+This repository's glyphs have been centralized.
+Primary location: ../governance/blog/glyphs/

--- a/scripts/validate-glyphs.js
+++ b/scripts/validate-glyphs.js
@@ -8,7 +8,12 @@
 const fs = require('fs');
 const path = require('path');
 
-const repoRoot = process.cwd();
+const localRoot = process.cwd();
+const projectName = path.basename(localRoot);
+const centralRoot = path.join(localRoot, '..', 'governance', projectName);
+
+// Prefer centralized governance path if it exists; fallback to local repo root.
+const repoRoot = (fs.existsSync(centralRoot) && fs.statSync(centralRoot).isDirectory()) ? centralRoot : localRoot;
 const meshPath = path.join(repoRoot, 'glyphs', 'MSH-000.md');
 
 function fail(msg){


### PR DESCRIPTION
This PR centralizes the blog repository's governance assets:\n\n- Moved docs/ and glyphs/ to code/governance/blog/{docs,glyphs}\n- Updated scripts/validate-glyphs.js to prefer centralized governance path with local fallback\n- Added repo-local README pointers under docs/ and glyphs/\n- Follows GVN-WORK-007 methodology (branch, checks, PR template)\n\nChecks:\n- npm run test:docs\n- npm run guard:internal\n\nPost-merge:\n- Optionally remove legacy docs/ and glyphs/ content (keeping or removing README pointers)\n