### PR TITLE
chore(ci): fetch centralized governance for glyph/docs checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
 - Up-to-date with main before PR: <!-- yes/no; rebase/merge main locally -->
 - Hidden layer protected (GOV-SEC-001): <!-- yes/no -->
 - Mesh index updated if needed (MSH-000): <!-- yes/no -->
+- Centralized governance fetched in CI: <!-- yes/no; CI checks out ava-sig/governance into ./governance using GOVERNANCE_REPO_TOKEN -->
 
 ## Runtime Ports
 - API: 3388
@@ -23,6 +24,7 @@
 - [ ] `npm run guard:internal` passes
 - [ ] CI glyph/docs checks pass
 - [ ] Branch policy check passes (rebased/merged main locally)
+- [ ] CI checks out centralized governance into `./governance` (ava-sig/governance via `GOVERNANCE_REPO_TOKEN`)
 
 ## Post-Merge Ritual (GOV-CORE-013)
 - [ ] Acknowledge that the merged branch will be deleted (auto-cleanup workflow runs on merge)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout central governance
+        uses: actions/checkout@v4
+        with:
+          repository: ava-sig/governance
+          ref: main
+          path: governance
+          token: ${{ secrets.GOVERNANCE_REPO_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -38,6 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout central governance
+        uses: actions/checkout@v4
+        with:
+          repository: ava-sig/governance
+          ref: main
+          path: governance
+          token: ${{ secrets.GOVERNANCE_REPO_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/glyph-docs.yml
+++ b/.github/workflows/glyph-docs.yml
@@ -26,6 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout central governance
+        uses: actions/checkout@v4
+        with:
+          repository: ava-sig/governance
+          ref: main
+          path: governance
+          token: ${{ secrets.GOVERNANCE_REPO_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -46,6 +53,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout central governance
+        uses: actions/checkout@v4
+        with:
+          repository: ava-sig/governance
+          ref: main
+          path: governance
+          token: ${{ secrets.GOVERNANCE_REPO_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/scripts/validate-glyphs.js
+++ b/scripts/validate-glyphs.js
@@ -10,10 +10,20 @@ const path = require('path');
 
 const localRoot = process.cwd();
 const projectName = path.basename(localRoot);
-const centralRoot = path.join(localRoot, '..', 'governance', projectName);
+
+// Support both layouts:
+// - Local dev: ../governance/{project}
+// - CI (checked out into workspace): ./governance/{project}
+const centralCandidates = [
+  path.join(localRoot, '..', 'governance', projectName),
+  path.join(localRoot, 'governance', projectName),
+];
+const foundCentral = centralCandidates.find(p => {
+  try { return fs.existsSync(p) && fs.statSync(p).isDirectory(); } catch { return false; }
+});
 
 // Prefer centralized governance path if it exists; fallback to local repo root.
-const repoRoot = (fs.existsSync(centralRoot) && fs.statSync(centralRoot).isDirectory()) ? centralRoot : localRoot;
+const repoRoot = foundCentral || localRoot;
 const meshPath = path.join(repoRoot, 'glyphs', 'MSH-000.md');
 
 function fail(msg){


### PR DESCRIPTION
CI now checks out ava-sig/governance into ./governance using GOVERNANCE_REPO_TOKEN (read-only).\n\n- Added checkout step to glyphs and tests jobs in ci.yml\n- Added checkout step to tests and validate-glyphs jobs in glyph-docs.yml\n- Validator already supports both ../governance/{project} and ./governance/{project}\n\nToken: GOVERNANCE_REPO_TOKEN (read)\nRepo: ava-sig/governance (private).