### PR TITLE
feat(web): light/dark theme toggle (edit-mode only), default light

### DIFF
--- a/apps/api/data/posts.json
+++ b/apps/api/data/posts.json
@@ -1,167 +1,20 @@
 [
   {
-    "id": "47f959c8-8b6d-4bf5-a8cb-35b3fae440a8",
-    "title": "ok",
-    "content": "",
-    "slug": "ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T11:14:02.949Z",
-    "updatedAt": "2025-09-09T11:14:02.949Z"
-  },
-  {
-    "id": "a0be6fc2-3437-4c4b-bbf1-a11f143f079b",
-    "title": "fallback ok",
-    "content": "",
-    "slug": "fallback-ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T11:14:02.935Z",
-    "updatedAt": "2025-09-09T11:14:02.935Z"
-  },
-  {
-    "id": "ca068a3c-8233-4f69-a40f-d73f258d3708",
-    "title": "JWT ok",
-    "content": "",
-    "slug": "jwt-ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T11:14:02.922Z",
-    "updatedAt": "2025-09-09T11:14:02.922Z"
-  },
-  {
-    "id": "abd3b633-d2ea-4efa-befc-1ff4ca92487a",
-    "title": "ok",
-    "content": "",
-    "slug": "ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T11:13:11.943Z",
-    "updatedAt": "2025-09-09T11:13:11.943Z"
-  },
-  {
-    "id": "e615408c-dabb-44bf-8415-b9599d036e3c",
-    "title": "fallback ok",
-    "content": "",
-    "slug": "fallback-ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T11:13:11.931Z",
-    "updatedAt": "2025-09-09T11:13:11.931Z"
-  },
-  {
-    "id": "f13f3228-7708-4e96-9f14-85009c4ab68b",
-    "title": "JWT ok",
-    "content": "",
-    "slug": "jwt-ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T11:13:11.907Z",
-    "updatedAt": "2025-09-09T11:13:11.907Z"
-  },
-  {
-    "id": "78739724-4d90-40fc-bb6c-00a047e2c0d9",
-    "title": "ok",
-    "content": "",
-    "slug": "ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T08:54:59.104Z",
-    "updatedAt": "2025-09-09T08:54:59.104Z"
-  },
-  {
-    "id": "c7f41464-7fb1-4b23-bc3f-a8e5717ad089",
-    "title": "fallback ok",
-    "content": "",
-    "slug": "fallback-ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T08:54:59.100Z",
-    "updatedAt": "2025-09-09T08:54:59.100Z"
-  },
-  {
-    "id": "df4496b8-348c-4110-918a-bcaeaf7b985c",
-    "title": "JWT ok",
-    "content": "",
-    "slug": "jwt-ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T08:54:59.092Z",
-    "updatedAt": "2025-09-09T08:54:59.092Z"
-  },
-  {
-    "id": "1783efd9-e018-4e53-8988-585e9a352f1d",
-    "title": "ok",
-    "content": "",
-    "slug": "ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T08:47:44.934Z",
-    "updatedAt": "2025-09-09T08:47:44.934Z"
-  },
-  {
-    "id": "a284e5fd-94f0-45f0-9a25-96cba6803159",
-    "title": "fallback ok",
-    "content": "",
-    "slug": "fallback-ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T08:47:44.926Z",
-    "updatedAt": "2025-09-09T08:47:44.926Z"
-  },
-  {
-    "id": "de94fff8-4c7b-4622-9e6a-c9402ee78e20",
-    "title": "JWT ok",
-    "content": "",
-    "slug": "jwt-ok",
-    "status": "draft",
-    "createdAt": "2025-09-09T08:47:44.919Z",
-    "updatedAt": "2025-09-09T08:47:44.919Z"
-  },
-  {
-    "id": "bfc64f4d-7d9b-4fbf-a02a-ee71658bf54f",
-    "title": "E2E Post 1756626588400",
-    "content": "Hello from E2E at 2025-08-31T07:49:48.400Z",
-    "slug": "e2e-post-1756626588400",
-    "status": "draft",
-    "createdAt": "2025-08-31T07:49:48.429Z",
-    "updatedAt": "2025-08-31T07:49:48.429Z"
-  },
-  {
-    "id": "6598bd4d-25ee-4e50-ae15-9102c4df8e9e",
-    "title": "ok",
-    "content": "",
-    "slug": "ok",
-    "status": "draft",
-    "createdAt": "2025-08-31T07:34:31.977Z",
-    "updatedAt": "2025-08-31T07:34:31.977Z"
-  },
-  {
-    "id": "d20249b9-37c3-4cb8-9949-032739983472",
-    "title": "fallback ok",
-    "content": "",
-    "slug": "fallback-ok",
-    "status": "draft",
-    "createdAt": "2025-08-31T07:34:31.973Z",
-    "updatedAt": "2025-08-31T07:34:31.973Z"
-  },
-  {
-    "id": "6235c23f-48bc-4436-959a-794b96af43eb",
-    "title": "JWT ok",
-    "content": "",
-    "slug": "jwt-ok",
-    "status": "draft",
-    "createdAt": "2025-08-31T07:34:31.958Z",
-    "updatedAt": "2025-08-31T07:34:31.958Z"
-  },
-  {
     "id": "c7f7480e-4dee-481d-958f-78ba0d7f7e97",
     "title": "i want a second redbull",
     "content": "https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExanllNnV4NXo0cXRqYTByejE2OHM3OGJva2UwanE2cTFoMXFpd2ltYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/javHxbM3JgrcY/giphy.gif",
     "createdAt": "2025-08-31T06:17:58.827Z",
-    "updatedAt": "2025-08-31T06:17:58.827Z"
+    "updatedAt": "2025-09-12T16:04:05.066Z",
+    "slug": "i-want-a-second-redbull",
+    "status": "draft"
   },
   {
     "id": "32aef0e6-964a-4f38-9a68-31fc08f70ee7",
     "title": "Updating the visual look of the blog ",
-    "content": "Since I've been engaged in a lot of projects: [@youandgreg](https://x.com/youandgreg) and [@hananaapp](https://x.com/hananaapp), I decided to develop my own blog posting platform because in 2025, no one EVER wants to deal with Wordpress or other CMS and its headaches.\nIt's all custom made and tailored baby !\n\n![image](http://localhost:3388/uploads/56aeadb3-dbc9-4de4-90e2-bd87a4aae5b4.png)\n",
+    "content": "Since I've been engaged in a lot of projects: [@youandgreg](https://x.com/youandgreg) and [@hananaapp](https://x.com/hananaapp), I decided to develop my own blog posting platform because in 2025, no one EVER wants to deal with Wordpress or other CMS and its headaches.\nIt's all custom made and tailored baby !\nhttps://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2FzM3BzbXQxcTlvdXhrdnJ1ZGF6cGIwcjlyeXp5M3Z0ZjJoYnAwZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/kuPIiwMUgKJaORFiVN/giphy.gif",
     "createdAt": "2025-08-30T15:40:09.061Z",
-    "updatedAt": "2025-08-30T16:03:40.217Z"
-  },
-  {
-    "id": "9828f1c9-9340-4876-800e-9272172cba31",
-    "title": "Algo, you're messing up ",
-    "content": "This is X's lowest point it seems by now\n\n![image](http://localhost:3388/uploads/23a18ef0-eaa9-40fe-af9b-5b0e3c277b97.png)\n",
-    "createdAt": "2025-08-30T12:55:39.638Z",
-    "updatedAt": "2025-08-30T15:33:47.744Z"
+    "updatedAt": "2025-09-12T16:20:41.507Z",
+    "slug": "updating-the-visual-look-of-the-blog",
+    "status": "draft"
   }
 ]

--- a/apps/api/data/settings.json
+++ b/apps/api/data/settings.json
@@ -1,0 +1,4 @@
+{
+  "defaultTheme": "dark",
+  "blogName": "localhost anghene"
+}

--- a/apps/web/app.vue
+++ b/apps/web/app.vue
@@ -40,6 +40,14 @@
               aria-hidden="true"
             />
           </template>
+          <!-- Theme toggle: visible only in edit mode -->
+          <button
+            v-if="auth.editing"
+            class="theme-indicator"
+            :aria-label="`Switch to ${theme.theme === 'dark' ? 'light' : 'dark'} theme`"
+            :title="`Theme: ${theme.theme}`"
+            @click="theme.toggleTheme()"
+          />
           <button
             class="edit-indicator"
             :class="{ on: auth.editing }"
@@ -116,8 +124,10 @@ import { useRoute, useRouter } from 'vue-router'
 import { onMounted, ref } from 'vue'
 import { useRuntimeConfig } from 'nuxt/app'
 import { useErrors } from '~/composables/useErrors'
+import { useTheme } from '~/stores/theme'
 
 const auth = useAuth()
+const theme = useTheme()
 const route = useRoute()
 const router = useRouter()
 const showLogin = ref(false)
@@ -322,4 +332,44 @@ body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI
   border-color: #1d4ed8;
   color: #fff;
 }
+/* Theme CSS variables: default light, override in .dark */
+:root {
+  /* base color channels as r g b (match Tailwind's rgb(var(--...)) usage) */
+  --base-bg: 250 250 250;        /* light bg */
+  --base-panel: 255 255 255;     /* light panel */
+  --base-border: 229 231 235;    /* zinc-200 */
+  --base-text: 17 24 39;         /* gray-900 */
+  --base-sub: 107 114 128;       /* gray-500 */
+}
+
+.dark:root {
+  --base-bg: 11 11 15;
+  --base-panel: 15 15 20;
+  --base-border: 35 35 41;
+  --base-text: 229 231 235;
+  --base-sub: 161 161 170;
+}
+
+/* Theme indicator, visually minimal */
+.theme-indicator {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  margin-right: 10px;
+  opacity: 0.95;
+  transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+  /* Light mode hint */
+  background: radial-gradient(circle at 65% 35%, #fde68a 15%, #f59e0b 45%, #2563eb 85%);
+  box-shadow: inset 0 0 0 2px rgba(0,0,0,0.35);
+}
+.dark .theme-indicator {
+  /* Dark mode hint */
+  background: radial-gradient(circle at 65% 35%, #93c5fd 15%, #2563eb 45%, #0ea5e9 85%);
+  box-shadow: 0 0 8px 2px rgba(59,130,246,0.35);
+}
+.theme-indicator:hover { opacity: 1; transform: translateY(-1px); }
+.theme-indicator:focus-visible { outline: 2px solid #2563eb; outline-offset: 2px; }
 </style>

--- a/apps/web/app.vue
+++ b/apps/web/app.vue
@@ -40,21 +40,23 @@
               aria-hidden="true"
             />
           </template>
-          <!-- Theme toggle: visible only in edit mode -->
-          <button
-            v-if="auth.editing"
-            class="theme-indicator"
-            :aria-label="`Switch to ${theme.theme === 'dark' ? 'light' : 'dark'} theme`"
-            :title="`Theme: ${theme.theme}`"
-            @click="theme.toggleTheme()"
-          />
-          <button
-            class="edit-indicator"
-            :class="{ on: auth.editing }"
-            aria-label="Edit mode status"
-            title="Edit mode"
-            @click="onIndicatorClick"
-          />
+          <div class="flex items-center gap-[10px]">
+            <!-- Theme toggle: visible only in edit mode -->
+            <button
+              v-if="auth.editing"
+              class="theme-indicator"
+              :aria-label="`Switch to ${theme.theme === 'dark' ? 'light' : 'dark'} theme`"
+              :title="`Theme: ${theme.theme}`"
+              @click="theme.toggleTheme()"
+            />
+            <button
+              class="edit-indicator"
+              :class="{ on: auth.editing }"
+              aria-label="Edit mode status"
+              title="Edit mode"
+              @click="onIndicatorClick"
+            />
+          </div>
         </ClientOnly>
       </div>
     </header>
@@ -358,7 +360,6 @@ body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  margin-right: 10px;
   opacity: 0.95;
   transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
   /* Light mode hint */

--- a/apps/web/assets/css/tailwind.css
+++ b/apps/web/assets/css/tailwind.css
@@ -22,7 +22,9 @@
   .focus-ring { @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/60 focus-visible:ring-offset-0; }
   .hover-lift { @apply transition-transform duration-normal ease-entrance hover:-translate-y-0.5 hover:shadow-lift; }
   .hover-ring { @apply transition ring-1 ring-transparent hover:ring-base-border/70; }
-  .prose-content { @apply prose prose-invert prose-zinc max-w-prose md:max-w-2xl; }
+  /* Use normal prose in light theme; invert only in dark for readability */
+  .prose-content { @apply prose prose-zinc max-w-prose md:max-w-2xl; }
+  .dark .prose-content { @apply prose-invert; }
   /* Enhance images inside prose for centered 3D presence */
   .prose-content img {
     display: block;
@@ -56,6 +58,7 @@
     filter: saturate(110%);
     pointer-events: none;
     z-index: 0;
+    opacity: 0.2; /* make background ring subtle in light theme */
   }
   .card-art::after { /* inner bevel + soft top sheen */
     content: "";
@@ -79,6 +82,7 @@
       inset 0 -2px 0 rgba(0,0,0,0.45);
     pointer-events: none;
     z-index: 0;
+    opacity: 0.2; /* reduce background graphics intensity to ~20% */
   }
   .card-art:hover::after {
     background:
@@ -87,6 +91,7 @@
       radial-gradient(130px 64px at 0% 100%, rgba(99,102,241,0.14), rgba(99,102,241,0) 60%),
       linear-gradient(180deg, rgba(255,255,255,0.07), rgba(255,255,255,0) 28%),
       linear-gradient(180deg, rgba(0,0,0,0) 70%, rgba(0,0,0,0.25));
+    opacity: 0.25; /* slightly stronger on hover, still subtle */
   }
 
   /* Scroll reveal utility */

--- a/apps/web/assets/css/tailwind.css
+++ b/apps/web/assets/css/tailwind.css
@@ -39,6 +39,12 @@
       inset 0 1px 0 rgba(255,255,255,0.06), /* top bevel */
       inset 0 -1px 0 rgba(0,0,0,0.35);      /* bottom bevel */
   }
+  /* In dark theme, keep a stronger inner bottom shadow for depth */
+  .dark .card-art::after {
+    box-shadow:
+      inset 0 1px 0 rgba(255,255,255,0.06),
+      inset 0 -2px 0 rgba(0,0,0,0.45);
+  }
 
   /* Artistic card bevel with gradient ring and subtle corner accents */
   .card-art { @apply relative overflow-hidden rounded-2xl; }
@@ -77,9 +83,9 @@
       radial-gradient(110px 54px at calc(0% + var(--px, 0px)) calc(100% + var(--py, 0px)), rgba(99,102,241,0.10), rgba(99,102,241,0) 60%),
       linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0) 28%),
       linear-gradient(180deg, rgba(0,0,0,0) 70%, rgba(0,0,0,0.25));
+    /* In light theme, avoid heavy inner bottom shadow to prevent double-line with the panel border */
     box-shadow:
-      inset 0 1px 0 rgba(255,255,255,0.06),
-      inset 0 -2px 0 rgba(0,0,0,0.45);
+      inset 0 1px 0 rgba(255,255,255,0.06);
     pointer-events: none;
     z-index: 0;
     opacity: 0.2; /* reduce background graphics intensity to ~20% */

--- a/apps/web/assets/css/tailwind.css
+++ b/apps/web/assets/css/tailwind.css
@@ -11,13 +11,13 @@
 @layer components {
   .container-page { @apply max-w-3xl mx-auto px-4 sm:px-6; }
   .panel { @apply bg-base-panel border border-base-border rounded-2xl shadow-subtle; }
-  .panel-muted { @apply bg-[#0e0e13] border border-base-border/70 rounded-2xl shadow-subtle; }
-  .btn { @apply inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium border border-base-border bg-[#15151b] text-base-text shadow-subtle hover:shadow-lift hover:-translate-y-0.5 transition; }
+  .panel-muted { @apply bg-base-panel border border-base-border/70 rounded-2xl shadow-subtle; }
+  .btn { @apply inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium border border-base-border bg-base-panel text-base-text shadow-subtle hover:shadow-lift hover:-translate-y-0.5 transition; }
   .btn-primary { @apply relative overflow-hidden inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium text-white shadow-subtle transition duration-normal ease-entrance; }
   .btn-primary { background: linear-gradient(180deg, #4f46e5 0%, #4338ca 100%); }
   .btn-primary:hover { filter: brightness(1.05); transform: translateY(-1px); box-shadow: 0 8px 24px rgba(49,46,129,0.35); }
   .btn-danger { @apply bg-rose-600/10 text-rose-300 border-rose-700 hover:bg-rose-600/20; }
-  .input { @apply w-full rounded-md bg-[#101014] border border-base-border px-3 py-2 text-base placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/50; }
+  .input { @apply w-full rounded-md bg-base-panel border border-base-border px-3 py-2 text-base-text placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/50; }
   .muted { @apply text-base-sub; }
   .focus-ring { @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/60 focus-visible:ring-offset-0; }
   .hover-lift { @apply transition-transform duration-normal ease-entrance hover:-translate-y-0.5 hover:shadow-lift; }

--- a/apps/web/components/UiToast.vue
+++ b/apps/web/components/UiToast.vue
@@ -25,9 +25,18 @@ const props = defineProps<{
 }>()
 
 const typeClass = computed(() => {
-  return props.type === 'error'
-    ? 'bg-rose-900/15 border-rose-700/40 text-rose-200'
-    : 'bg-emerald-900/15 border-emerald-700/40 text-emerald-200'
+  if (props.type === 'error') {
+    // Light theme (default): readable dark text on light background
+    // Dark theme: keep subtle dark-background styling
+    return [
+      'bg-rose-50 border-rose-200 text-rose-700',
+      'dark:bg-rose-900/15 dark:border-rose-700/40 dark:text-rose-200',
+    ].join(' ')
+  }
+  return [
+    'bg-emerald-50 border-emerald-200 text-emerald-700',
+    'dark:bg-emerald-900/15 dark:border-emerald-700/40 dark:text-emerald-200',
+  ].join(' ')
 })
 </script>
 

--- a/apps/web/pages/index.vue
+++ b/apps/web/pages/index.vue
@@ -5,10 +5,11 @@
       Posts
     </h2>
 
-    <section
-      v-if="auth.editing"
-      class="panel-muted p-4 mt-4"
-    >
+    <ClientOnly>
+      <section
+        v-if="auth.editing"
+        class="panel-muted p-4 mt-4"
+      >
       <h3 class="text-base font-medium mb-3">
         New Post
       </h3>
@@ -52,7 +53,8 @@
           </button>
         </div>
       </form>
-    </section>
+      </section>
+    </ClientOnly>
 
     <section class="mt-6">
       <div
@@ -111,15 +113,17 @@
               class="timeline"
               aria-hidden="true"
             />
-            <button
-              v-if="auth.editing"
-              class="card-close focus-ring"
-              aria-label="Delete post"
-              title="Delete"
-              @click.stop="remove(p.id)"
-            >
-              ×
-            </button>
+            <ClientOnly>
+              <button
+                v-if="auth.editing"
+                class="card-close focus-ring"
+                aria-label="Delete post"
+                title="Delete"
+                @click.stop="remove(p.id)"
+              >
+                ×
+              </button>
+            </ClientOnly>
             <a
               class="card-xshare focus-ring"
               :href="xShareUrl(p)"

--- a/apps/web/pages/index.vue
+++ b/apps/web/pages/index.vue
@@ -456,6 +456,14 @@ onMounted(async () => {
 <style scoped>
 .prose-content {
   white-space: pre-wrap; /* preserve newlines and blank lines */
+  /* Ensure very long words/URLs wrap within the card */
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+/* Wrap long titles as well */
+.card h4 {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 .card {
   position: relative;

--- a/apps/web/stores/theme.ts
+++ b/apps/web/stores/theme.ts
@@ -1,0 +1,50 @@
+import { defineStore } from 'pinia'
+
+export type Theme = 'light' | 'dark'
+
+interface ThemeState {
+  theme: Theme
+}
+
+export const useTheme = defineStore('theme', {
+  state: (): ThemeState => ({
+    theme: 'light', // default theme
+  }),
+  actions: {
+    setTheme(next: Theme) {
+      this.theme = next
+      this.applyThemeClass()
+      this.persist()
+    },
+    toggleTheme() {
+      this.setTheme(this.theme === 'dark' ? 'light' : 'dark')
+    },
+    applyThemeClass() {
+      if (typeof document === 'undefined') return
+      const el = document.documentElement
+      if (this.theme === 'dark') el.classList.add('dark')
+      else el.classList.remove('dark')
+    },
+    persist() {
+      try { localStorage.setItem('ui.theme', this.theme) } catch {}
+    },
+    load() {
+      if (typeof window === 'undefined') return
+      try {
+        const t = (localStorage.getItem('ui.theme') as Theme) || 'light'
+        this.theme = (t === 'dark' ? 'dark' : 'light')
+      } catch { this.theme = 'light' }
+      this.applyThemeClass()
+    },
+  },
+})
+
+// Auto-load on first import (client-side)
+if (typeof window !== 'undefined') {
+  try {
+    const store = (useTheme as any)()
+    if (store && typeof store.load === 'function') store.load()
+  } catch {
+    // Pinia may not be ready at import time; safe to ignore
+  }
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -14,11 +14,13 @@ export default {
     extend: {
       colors: {
         base: {
-          bg: '#0b0b0f',
-          panel: '#0f0f14',
-          border: '#232329',
-          text: '#e5e7eb',
-          sub: '#a1a1aa'
+          // Use CSS variables so we can switch themes by toggling the 'dark' class
+          // Supports alpha via Tailwind's <alpha-value> token
+          bg: 'rgb(var(--base-bg) / <alpha-value>)',
+          panel: 'rgb(var(--base-panel) / <alpha-value>)',
+          border: 'rgb(var(--base-border) / <alpha-value>)',
+          text: 'rgb(var(--base-text) / <alpha-value>)',
+          sub: 'rgb(var(--base-sub) / <alpha-value>)'
         }
       },
       transitionDuration: {


### PR DESCRIPTION
Summary
Persist theme and blog name via a simple settings API, make the UI fully theme-aware, resolve hydration issues, and ensure the post list renders reliably even when SSR fetch misses.

Glyphs Referenced
Primary: GVN-007, GVN-008
Related: GVN-002, GVN-004, MSH-000
Governance Adherence
Conventional commits followed (GVN-002): yes
Branch rule respected (GVN-004): feat/web-theme-toggle-edit-mode
Created from latest main: yes
Up-to-date with main before PR: yes
Mesh index updated if needed (MSH-000): n/a (governance repo hosts glyphs)
Changes
API
apps/api/src/app.js
Add file-backed settings.json persistence with defaults:
defaultTheme: 'light'
blogName: 'Glyphic Blog'
Endpoints:
GET /api/settings → { defaultTheme, blogName }
PUT /api/settings (auth) → updates { defaultTheme, blogName }
ensureStore() guarantees settings.json exists
apps/api/data/settings.json (created)
Web: Theme, modal, and persistence
apps/web/stores/theme.ts
Load server default theme for guests if no local preference
Keep localStorage override precedence; apply DOM class accordingly
apps/web/app.vue
Theme toggle persists defaultTheme via PUT /api/settings when in edit mode
Blog name: saving the title persists blogName to settings; guests load it when no local override
Modal styling made theme-aware; JWT textarea uses .input; buttons use theme-aware .btn
Web: Post list readability and visibility
apps/web/pages/index.vue
SSR fetch remains; added client-side fallback fetch when SSR misses
After client fetch: await nextTick() and re-run setupReveal() so cards become visible
Wrap long words/URLs in titles and content to prevent clipping
Hydration fixes: wrap auth.editing UI in ClientOnly (composer section and per-card delete button)
apps/web/assets/css/tailwind.css
Theme-aware panel/input/button colors (new-post form and buttons)
Reduce card background visuals to ~20% opacity (25% on hover) for better contrast
Web: Toast readability
apps/web/components/UiToast.vue
Light theme: bg-emerald-50/rose-50 with dark text
Dark theme: keep translucent variants
Web: Config hygiene
apps/web/nuxt.config.ts
Restored valid config; retain public apiBase and existing runtime config
Removed incorrect auto-import manipulations
Why these changes
Ensure consistent, readable theming across light/dark modes
Persist admin selections (default theme and blog name) for all guests
Resolve hydration mismatches due to SSR/CSR divergence around editing-gated UI
Guarantee post list renders even when SSR fetch cannot reach the API in containerized dev
Validation & Checks
 Local: posts render after client fetch; cards visible (reveal re-attached)
 Local: theme toggle persists default; guests pick up server default with no local override
 Local: blog name persists on save; guests pick up from settings with no local override
 Toasts readable on both themes
 Hydration warnings resolved by ClientOnly gating
 npm run test:docs (root) – passes
 npm run guard:internal (root) – passes
 CI glyph/docs checks – pending on PR
 Branch policy check – rebased/merged main locally
Notes / Follow-ups
SSR inside Docker may still not reach the API (localhost mismatch). Client fallback now guarantees rendering. Optionally, we can add a private apiInternalBase (e.g., http://api:3388/) for SSR only.
If you want server defaults to override existing local preferences for all users, I can invert the current precedence in the theme store.
Screenshots / Logs
Toasts and card visuals updated; logs show “[posts] fetched on client …” during client fallback.